### PR TITLE
add config.OCRD_DOWNLOAD_INPUT

### DIFF
--- a/src/ocrd/cli/__init__.py
+++ b/src/ocrd/cli/__init__.py
@@ -29,6 +29,8 @@ Variables:
 \b
 {config.describe('OCRD_DOWNLOAD_TIMEOUT')}
 \b
+{config.describe('OCRD_DOWNLOAD_INPUT')}
+\b
 {config.describe('OCRD_METS_CACHING')}
 \b
 {config.describe('OCRD_MAX_PROCESSOR_CACHE')}

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -29,6 +29,7 @@ from ocrd_utils import (
     VERSION as OCRD_VERSION,
     MIMETYPE_PAGE,
     MIME_TO_EXT,
+    config,
     getLogger,
     initLogging,
     list_resource_candidates,
@@ -111,7 +112,7 @@ class Processor():
             input_file_grp=None,
             output_file_grp=None,
             page_id=None,
-            download_files=True,
+            download_files=config.OCRD_DOWNLOAD_INPUT,
             version=None
     ):
         """
@@ -137,7 +138,8 @@ class Processor():
                  (or empty for all pages). \
                  Deprecated since version 3.0: Should be ``None`` here, but then needs to be set \
                  before processing.
-             download_files (boolean): Whether input files will be downloaded prior to processing.
+             download_files (boolean): Whether input files will be downloaded prior to processing, \
+                 defaults to :py:attr:`ocrd_utils.config.OCRD_DOWNLOAD_INPUT` which is ``True`` by default
         """
         if ocrd_tool is not None:
             deprecation_warning("Passing 'ocrd_tool' as keyword argument to Processor is deprecated - "

--- a/src/ocrd_utils/config.py
+++ b/src/ocrd_utils/config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from tempfile import gettempdir
 from textwrap import fill, indent
 
+_validator_boolean = lambda val: isinstance(val, bool) or str.lower(val) in ('true', 'false', '0', '1')
+_parser_boolean = lambda val: bool(val) if isinstance(val, (int, bool)) else str.lower(val) in ('true', '1')
 
 class OcrdEnvVariable():
 
@@ -102,8 +104,8 @@ config = OcrdEnvConfig()
 
 config.add('OCRD_METS_CACHING',
     description='If set to `true`, access to the METS file is cached, speeding in-memory search and modification.',
-    validator=lambda val: val in ('true', 'false', '0', '1'),
-    parser=lambda val: val in ('true', '1'))
+    validator=_validator_boolean,
+    parser=_parser_boolean)
 
 config.add('OCRD_MAX_PROCESSOR_CACHE',
     description="Maximum number of processor instances (for each set of parameters) to be kept in memory (including loaded models) for processing workers or processor servers.",
@@ -125,7 +127,7 @@ config.add("OCRD_PROFILE_FILE",
     description="If set, then the CPU profile is written to this file for later peruse with a analysis tools like snakeviz")
 
 config.add("OCRD_DOWNLOAD_RETRIES",
-    description="Number of times to retry failed attempts for downloads of resource or workspace files.",
+    description="Number of times to retry failed attempts for downloads of resources or workspace files.",
     validator=int,
     parser=int)
 
@@ -140,6 +142,12 @@ def _ocrd_download_timeout_parser(val):
 config.add("OCRD_DOWNLOAD_TIMEOUT",
     description="Timeout in seconds for connecting or reading (comma-separated) when downloading.",
     parser=_ocrd_download_timeout_parser)
+
+config.add("OCRD_DOWNLOAD_INPUT",
+    description="Whether to download files not present locally during processing",
+    default=(True, True),
+    validator=_validator_boolean,
+    parser=_parser_boolean)
 
 config.add("OCRD_NETWORK_SERVER_ADDR_PROCESSING",
         description="Default address of Processing Server to connect to (for `ocrd network client processing`).",
@@ -190,5 +198,5 @@ config.add("XDG_CONFIG_HOME",
 config.add("OCRD_LOGGING_DEBUG",
     description="Print information about the logging setup to STDERR",
     default=(True, False),
-    validator=lambda val: isinstance(val, bool) or str.lower(val) in ('true', 'false', '0', '1'),
-    parser=lambda val:  val if isinstance(val, (int, bool)) else str.lower(val) in ('true', '1'))
+    validator=_validator_boolean,
+    parser=_parser_boolean)


### PR DESCRIPTION
> > I would add a `ocrd_utils.config` variable `OCRD_PROCESSOR_DOWNLOADS` which, if set, overrides the behavior of the kwarg. And of course add the config to the `ocrd --help` output.
> 
> Yes, but I would call it `OCRD_DOWNLOAD_INPUT[=true]`.

cd4c96c9

> And we should also apply `OCRD_DOWNLOAD_RETRIES` and `OCRD_DOWNLOAD_TIMEOUT` here.

Since the `Workspace.download_file` call delegates to `Resolver.download_to_directory` which implements retries and timeouts, these variables should already be effective.

> (and change their description – they currently only cover resmgr activity but are documented as covering only workspace files).

But isn't this about workspace files? Ideas for better docs for these variables appreciated.