### PR TITLE
define self.logger in processor base constructor

### DIFF
--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -47,6 +47,8 @@ from ocrd_modelfactory import page_from_file
 # XXX imports must remain for backwards-compatibility
 from .helpers import run_cli, run_processor, generate_processor_help # pylint: disable=unused-import
 
+_logger = getLogger('ocrd.processor.base')
+
 class ResourceNotFoundError(FileNotFoundError):
     """
     An exception signifying the requested processor resource
@@ -175,6 +177,9 @@ class Processor():
         if not report.is_valid:
             raise ValueError("Invalid parameters %s" % report.errors)
         self.parameter = parameter
+        # NOTE: this is the logger to be used by processor implementations,
+        # `processor.base` default implementations should use :py:attr:`_logger`
+        self.logger = getLogger(f'ocrd.processor.{self.__class__.__name__}')
         # workaround for deprecated#72 (@deprecated decorator does not work for subclasses):
         setattr(self, 'process',
                 deprecated(version='3.0', reason='process() should be replaced with process_page() and process_workspace()')(getattr(self, 'process')))
@@ -562,7 +567,6 @@ class Processor():
         if not self.input_file_grp:
             raise ValueError("Processor is missing input fileGrp")
 
-        LOG = getLogger('ocrd.processor.base')
         ifgs = self.input_file_grp.split(",")
         # Iterating over all files repeatedly may seem inefficient at first sight,
         # but the unnecessary OcrdFile instantiations for posterior fileGrp filtering
@@ -582,13 +586,13 @@ class Processor():
                        f"compare '{self.page_id}' with the output of 'orcd workspace list-page'.")
                 if on_error == 'abort':
                     raise ValueError(msg)
-                LOG.warning(msg)
+                _logger.warning(msg)
             for file_ in files_:
                 if not file_.pageId:
                     continue
                 ift = pages.setdefault(file_.pageId, [None]*len(ifgs))
                 if ift[i]:
-                    LOG.debug("another file %s for page %s in input file group %s", file_.ID, file_.pageId, ifg)
+                    _logger.debug("another file %s for page %s in input file group %s", file_.ID, file_.pageId, ifg)
                     # fileGrp has multiple files for this page ID
                     if mimetype:
                         # filter was active, this must not happen
@@ -627,14 +631,14 @@ class Processor():
                         else:
                             raise Exception("Unknown 'on_error' strategy '%s'" % on_error)
                 else:
-                    LOG.debug("adding file %s for page %s to input file group %s", file_.ID, file_.pageId, ifg)
+                    _logger.debug("adding file %s for page %s to input file group %s", file_.ID, file_.pageId, ifg)
                     ift[i] = file_
         ifts = list()
         for page, ifiles in pages.items():
             for i, ifg in enumerate(ifgs):
                 if not ifiles[i]:
                     # other fallback options?
-                    LOG.error('found no page %s in file group %s',
+                    _logger.error('found no page %s in file group %s',
                               page, ifg)
             if ifiles[0] or not require_first:
                 ifts.append(tuple(ifiles))

--- a/src/ocrd/processor/builtin/dummy_processor.py
+++ b/src/ocrd/processor/builtin/dummy_processor.py
@@ -32,7 +32,6 @@ class DummyProcessor(Processor):
         return OcrdPageResult(input_pcgts[0])
 
     def process_page_file(self, *input_files: Optional[Union[OcrdFile, ClientSideOcrdFile]]) -> None:
-        LOG = getLogger('ocrd.dummy')
         input_file = input_files[0]
         assert input_file
         assert input_file.local_filename
@@ -57,7 +56,7 @@ class DummyProcessor(Processor):
             pcgts = self.process_page_pcgts(pcgts).pcgts
             pcgts.set_pcGtsId(file_id)
             self.add_metadata(pcgts)
-            LOG.info("Add PAGE-XML %s generated for %s", file_id, output_file)
+            self.logger.info("Add PAGE-XML %s generated for %s", file_id, output_file)
             self.workspace.add_file(file_id=file_id,
                                     file_grp=self.output_file_grp,
                                     page_id=input_file.pageId,


### PR DESCRIPTION
I was overthinking the problem here. As long as we don't use `self.logger` in the base processor - and I see no reason we'd need that - we can define `self.logger` to be used by processors.