### PR TITLE
ocrd_utils.introspect.freeze_args: retain lru_cache methods in wrapper

### DIFF
--- a/src/ocrd_utils/introspect.py
+++ b/src/ocrd_utils/introspect.py
@@ -34,6 +34,9 @@ def freeze_args(func):
         args = tuple([frozendict(arg) if isinstance(arg, dict) else arg for arg in args])
         kwargs = {k: frozendict(v) if isinstance(v, dict) else v for k, v in kwargs.items()}
         return func(*args, **kwargs)
+    for to_copy in ('cache_info', 'cache_clear'):
+        if hasattr(func, to_copy):
+            setattr(wrapped, to_copy, getattr(func, to_copy))
     return wrapped
 
 


### PR DESCRIPTION
Otherwise with

```python
@freeze_args
@lru_cache
def foo(...)
```

you would not be able to do `foo.empty_cache()` or `foo.cache_info()`.
