### PR TITLE
Processor.metadata_location property to specify where in the package ocrd-tool.json is found

### DIFF
--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -103,11 +103,18 @@ class Processor():
     """
 
     @property
+    def metadata_location(self) -> str:
+        """
+        Location of `ocrd-tool.json` inside the package. By default we expect it in the root of the module
+        """
+        return 'ocrd-tool.json'
+
+    @property
     def metadata(self) -> dict:
         """the ocrd-tool.json dict of the package"""
         if hasattr(self, '_metadata'):
             return self._metadata
-        self._metadata = json.loads(resource_string(self.__module__.split('.')[0], 'ocrd-tool.json'))
+        self._metadata = json.loads(resource_string(self.__module__.split('.')[0], self.metadata_location))
         report = OcrdToolValidator.validate(self._metadata)
         if not report.is_valid:
             # FIXME: remove when bertsky/core#10 is merged


### PR DESCRIPTION
This is necessary for packages that use namespaces (like eynollah) and potentially other non-standard locations for `ocrd-tool.json`.

I think having this additional property in core is better than having to reimplement `self.metadata`, including the validation, in a processor.