### PR TITLE
Processor.parameter: make property always return a (frozen)dict

### DIFF
--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -206,22 +206,23 @@ class Processor():
         return self.metadata['tools'][self.executable]
 
     @property
-    def parameter(self) -> Optional[dict]:
+    def parameter(self) -> frozendict[str, Any]:
         """the runtime parameter dict to be used by this processor"""
         if hasattr(self, '_parameter'):
             return self._parameter
-        return None
+        return frozendict({})
 
     @parameter.setter
     def parameter(self, parameter : dict) -> None:
-        if self.parameter is not None:
+        if hasattr(self, '_parameter'):
             self.shutdown()
+            delattr(self, '_parameter')
         parameterValidator = ParameterValidator(self.ocrd_tool)
         report = parameterValidator.validate(parameter)
         if not report.is_valid:
             raise ValueError(f'Invalid parameters:\n{report.to_xml()}')
         # make parameter dict read-only
-        self._parameter = frozendict(parameter)
+        self._parameter : frozendict[str, Any] = frozendict(parameter)
         # (re-)run setup to load models etc
         self.setup()
 

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -16,7 +16,7 @@ import json
 import os
 from os import getcwd
 from pathlib import Path
-from typing import List, Optional, Union, get_args
+from typing import Any, List, Optional, Union, get_args
 import sys
 import inspect
 import tarfile
@@ -300,7 +300,7 @@ class Processor():
         self._finalizer = weakref.finalize(self, self.shutdown)
         # workaround for deprecated#72 (@deprecated decorator does not work for subclasses):
         setattr(self, 'process',
-                deprecated(version='3.0', reason='process() should be replaced with process_page() and process_workspace()')(getattr(self, 'process')))
+                deprecated(version='3.0', reason='process() should be replaced with process_page_pcgts() or process_page_file() or process_workspace()')(getattr(self, 'process')))
 
     def show_help(self, subcommand=None):
         """

--- a/src/ocrd/processor/helpers.py
+++ b/src/ocrd/processor/helpers.py
@@ -358,7 +358,7 @@ Options:
 # not decorated here but at runtime (on first use)
 #@freeze_args
 #@lru_cache(maxsize=config.OCRD_MAX_PROCESSOR_CACHE)
-def get_cached_processor(parameter: dict, processor_class):
+def get_cached_processor(parameter: dict, processor_class) -> Optional['Processor']:
     """
     Call this function to get back an instance of a processor.
     The results are cached based on the parameters.
@@ -382,7 +382,7 @@ def get_processor(
         input_file_grp: Optional[List[str]] = None,
         output_file_grp: Optional[List[str]] = None,
         instance_caching: bool = False,
-):
+) -> 'Processor':
     if processor_class:
         if parameter is None:
             parameter = {}

--- a/src/ocrd/processor/helpers.py
+++ b/src/ocrd/processor/helpers.py
@@ -377,10 +377,10 @@ def get_cached_processor(parameter: dict, processor_class):
 def get_processor(
         processor_class,
         parameter: Optional[dict] = None,
-        workspace: Workspace = None,
-        page_id: str = None,
-        input_file_grp: List[str] = None,
-        output_file_grp: List[str] = None,
+        workspace: Optional[Workspace] = None,
+        page_id: Optional[str] = None,
+        input_file_grp: Optional[List[str]] = None,
+        output_file_grp: Optional[List[str]] = None,
         instance_caching: bool = False,
 ):
     if processor_class:
@@ -401,6 +401,7 @@ def get_processor(
         else:
             # avoid passing workspace already (deprecated chdir behaviour)
             processor = processor_class(None, parameter=parameter)
+        assert processor
         # set current processing parameters
         processor.workspace = workspace
         processor.page_id = page_id

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import json
 import os
 import re
@@ -72,15 +73,15 @@ class DummyProcessorWithRequiredParameters(Processor):
     def process(self): pass
 
 class DummyProcessorWithOutput(Processor):
-    @property
+    @cached_property
     def ocrd_tool(self):
         return DUMMY_TOOL
 
-    @property
+    @cached_property
     def version(self):
         return '0.0.1'
 
-    @property
+    @cached_property
     def executable(self):
         return 'ocrd-test'
 
@@ -104,15 +105,15 @@ class DummyProcessorWithOutput(Processor):
             )
 
 class DummyProcessorWithOutputFailures(Processor):
-    @property
+    @cached_property
     def ocrd_tool(self):
         return DUMMY_TOOL
 
-    @property
+    @cached_property
     def version(self):
         return '0.0.1'
 
-    @property
+    @cached_property
     def executable(self):
         return 'ocrd-test'
 

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import json
 from contextlib import ExitStack
 
@@ -185,7 +186,7 @@ class TestProcessor(TestCase):
 
     def test_params(self):
         class ParamTestProcessor(Processor):
-            @property
+            @cached_property
             def ocrd_tool(self):
                 return {}
         proc = ParamTestProcessor(None)

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -5,6 +5,8 @@ from contextlib import ExitStack
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from os import environ
+
+from frozendict import frozendict
 from tests.base import CapturingTestCase as TestCase, assets, main, copy_of_directory # pylint: disable=import-error, no-name-in-module
 from tests.data import (
     DummyProcessor,
@@ -149,7 +151,7 @@ class TestProcessor(TestCase):
 
     def test_params_missing_required(self):
         proc = DummyProcessorWithRequiredParameters(None)
-        assert proc.parameter is None
+        assert not proc.parameter
         with self.assertRaisesRegex(ValueError, 'is a required property'):
             proc.parameter = {}
         with self.assertRaisesRegex(ValueError, 'is a required property'):
@@ -190,7 +192,7 @@ class TestProcessor(TestCase):
             def ocrd_tool(self):
                 return {}
         proc = ParamTestProcessor(None)
-        self.assertEqual(proc.parameter, None)
+        self.assertEqual(proc.parameter, frozendict({}))
         # get_processor will set to non-none and validate
         proc = get_processor(ParamTestProcessor)
         self.assertEqual(proc.parameter, {})


### PR DESCRIPTION
What I want is for processor developers to be certain that `self.parameter` is set and a (frozen)dict in `self.setup`.

IIUC (big if), the reason for `@property self.parameter` returning `None` is to differentiate uninitialized `_parameter` from just `_parameter` being an empty dict because no parameters were given and there's no defaults.

But we can check for that condition by seeing whether `hasattr(self, '_parameter')` just as well and `delattr(self, '_parameter')` on re-assignment.

In the tests we can replace `p.parameter is not None` with either `p.parameter == frozendict({})` or `not p.parameter`. Which would also be true for regular empty parameter dict - in that case we could check for `hasattr(proc, '_parameter`) if we really want to check the same condition as `proc.parameter is None` like before.

