### PR TITLE
Processor parallel pages: switch from multithreading to multiprocessing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ httpx>=0.22.0
 importlib_metadata ; python_version < '3.8'
 importlib_resources ; python_version < '3.10'
 jsonschema>=4
+loky
 lxml
 memory-profiler >= 0.58.0
 # XXX explicitly do not restrict the numpy version because different

--- a/src/ocrd/decorators/__init__.py
+++ b/src/ocrd/decorators/__init__.py
@@ -13,7 +13,6 @@ from ocrd_utils import (
     redirect_stderr_and_stdout_to_file,
 )
 from ocrd_validators import WorkspaceValidator
-from ocrd_network import ProcessingWorker, ProcessorServer, AgentType
 
 from ..resolver import Resolver
 from ..processor.base import ResourceNotFoundError, run_processor
@@ -22,8 +21,6 @@ from .loglevel_option import ocrd_loglevel
 from .parameter_option import parameter_option, parameter_override_option
 from .ocrd_cli_options import ocrd_cli_options
 from .mets_find_options import mets_find_options
-
-SUBCOMMANDS = [AgentType.PROCESSING_WORKER, AgentType.PROCESSOR_SERVER]
 
 
 def ocrd_cli_wrap_processor(
@@ -88,11 +85,9 @@ def ocrd_cli_wrap_processor(
     if list_resources:
         processor.list_resources()
         sys.exit()
-    if subcommand:
+    if subcommand or address or queue or database:
         # Used for checking/starting network agents for the WebAPI architecture
         check_and_run_network_agent(processorClass, subcommand, address, database, queue)
-    elif address or queue or database:
-        raise ValueError(f"Subcommand options --address --queue and --database are only valid for subcommands: {SUBCOMMANDS}")
 
     # from here: single-run processing context
     initLogging()
@@ -162,6 +157,11 @@ def ocrd_cli_wrap_processor(
 def check_and_run_network_agent(ProcessorClass, subcommand: str, address: str, database: str, queue: str):
     """
     """
+    from ocrd_network import ProcessingWorker, ProcessorServer, AgentType
+    SUBCOMMANDS = [AgentType.PROCESSING_WORKER, AgentType.PROCESSOR_SERVER]
+
+    if not subcommand:
+        raise ValueError(f"Subcommand options --address --queue and --database are only valid for subcommands: {SUBCOMMANDS}")
     if subcommand not in SUBCOMMANDS:
         raise ValueError(f"SUBCOMMAND can only be one of {SUBCOMMANDS}")
 

--- a/src/ocrd/processor/base.py
+++ b/src/ocrd/processor/base.py
@@ -704,6 +704,8 @@ class Processor():
             if config.OCRD_EXISTING_OUTPUT == 'OVERWRITE':
                 # too late here, must not happen
                 raise Exception(f"got {err} despite OCRD_EXISTING_OUTPUT==OVERWRITE")
+        except KeyboardInterrupt:
+            raise
         # broad coverage of output failures (including TimeoutError)
         except Exception as err:
             # FIXME: add re-usable/actionable logging
@@ -1113,6 +1115,7 @@ def _page_worker_set_ctxt(processor):
     """
     global _page_worker_processor
     _page_worker_processor = processor
+
 def _page_worker(timeout, *input_files):
     """
     Wraps a `Processor.process_page_file` call as payload (call target)

--- a/src/ocrd_utils/logging.py
+++ b/src/ocrd_utils/logging.py
@@ -48,6 +48,7 @@ __all__ = [
 
 # These are the loggers we add handlers to
 ROOT_OCRD_LOGGERS = [
+    '',
     'ocrd',
     'ocrd_network'
 ]
@@ -191,7 +192,10 @@ def initLogging(builtin_only=False, force_reinit=False, silent=not config.OCRD_L
         ocrd_handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_TIMEFMT))
         ocrd_handler.setLevel(logging.DEBUG)
         for logger_name in ROOT_OCRD_LOGGERS:
-            logging.getLogger(logger_name).addHandler(ocrd_handler)
+            logger = logging.getLogger(logger_name)
+            logger.addHandler(ocrd_handler)
+            if logger_name:
+                logger.propagate = False # avoid duplication (from root handler)
         for logger_name, logger_level in LOGGING_DEFAULTS.items():
             logging.getLogger(logger_name).setLevel(logger_level)
     _initialized_flag = True
@@ -210,7 +214,7 @@ def disableLogging(silent=not config.OCRD_LOGGING_DEBUG):
     # logging.basicConfig(level=logging.CRITICAL)
     # logging.disable(logging.ERROR)
     # remove all handlers for the ocrd logger
-    for logger_name in ROOT_OCRD_LOGGERS + ['']:
+    for logger_name in ROOT_OCRD_LOGGERS:
         for handler in logging.getLogger(logger_name).handlers[:]:
             logging.getLogger(logger_name).removeHandler(handler)
     for logger_name in LOGGING_DEFAULTS:

--- a/tests/processor/test_processor.py
+++ b/tests/processor/test_processor.py
@@ -277,7 +277,6 @@ class TestProcessor(TestCase):
         assert len(ws.mets.find_all_files(fileGrp="OCR-D-OUT")) == len(ws.mets.find_all_files(fileGrp="OCR-D-IMG"))
         config.OCRD_EXISTING_OUTPUT = 'OVERWRITE'
         config.OCRD_PROCESSING_PAGE_TIMEOUT = 1
-        from concurrent.futures import TimeoutError
         with pytest.raises(TimeoutError) as exc:
             run_processor(DummyProcessorWithOutputSleep, workspace=ws,
                           input_file_grp="OCR-D-IMG",


### PR DESCRIPTION
This changes the `concurrent.futures.ThreadPoolExecutor` for management of page worker tasks to a `loky.ProcessPoolExecutor` for the same purpose.

Reasons for this:
- multithreading only allows utilising the potential from concurrent I/O or networking, but due to the Python GIL is not and cannot be truly **multiscalar**
- multiprocessing also avoids problems with processors using libraries that are not thread-safe (think Tesseract)
- the Python stdlib's implementation in `concurrent.futures` have long been [buggy](https://github.com/python/cpython/commits/aac89b54c5ee03c4d64fbdfbb6ea3001e26aa83a/Lib/concurrent/futures/process.py), esp. the memory leak and the `shutdown` deadlock. This has been haunting us in Python 3.8 but will not be backported before 3.10. In search for external backports I came across [loky](https://github.com/joblib/loky) which turns out to be the actual origin for all the recent robustness improvements in stdlib (they merely cherry-picked from their standalone implementation). Since it is still available as an external library, supports 3.8 and is well maintained, I switched  to this as a dependency.

I spent a lot of time trying to make error handling and shutdown really work well under the multiprocessing regime. Also, I learned that it is crucial when doing multiprocessing to avoid spawning any threads before forking. 

**Forking** (rather than spawning fresh child processes) is necessary, because our API needs to run `Processor.process_page_file` on the worker, where the latter is defined by subclasses: it is not possible (due to unpicklable objects in `Processor`) to serialise the `self` when sending it to children, and would not be feasible either. By forking, we can share the processor instance via global variable, and send tasks (containing the `CliendSideOcrdFile` objects) and results via queues with minimal overhead.

EDIT: Note that `fork` means that it will not work on Windows, and MacOS might be problematic (see [stdlib docs](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)). AFAICS the issue with forking is precisely that one absolutely must avoid having multiple threads _before_ the fork (which apparently on MacOS is not guaranteed because of some system libraries)